### PR TITLE
Enable localnet env

### DIFF
--- a/fcl-sample/build.gradle.kts
+++ b/fcl-sample/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.application")
-    id("com.google.gms.google-services")
     id("com.google.firebase.appdistribution")
     kotlin("android")
     kotlin("kapt")

--- a/fcl/build.gradle.kts
+++ b/fcl/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     kotlin("plugin.serialization")
 }
 
-setupLibraryModule(name = "com.portto.fcl", publish = true, document = false) {
+setupLibraryModule(name = "com.portto.fcl", publish = false, document = false) {
     buildFeatures {
         viewBinding = true
     }

--- a/fcl/src/main/java/com/portto/fcl/Fcl.kt
+++ b/fcl/src/main/java/com/portto/fcl/Fcl.kt
@@ -6,9 +6,7 @@ import com.nftco.flow.sdk.FlowTransactionResult
 import com.nftco.flow.sdk.cadence.Field
 import com.portto.fcl.config.AppDetail
 import com.portto.fcl.config.Config
-import com.portto.fcl.config.Config.Option.App
-import com.portto.fcl.config.Config.Option.Env
-import com.portto.fcl.config.Config.Option.WalletProviders
+import com.portto.fcl.config.Config.Option.*
 import com.portto.fcl.config.Network
 import com.portto.fcl.model.CompositeSignature
 import com.portto.fcl.model.Result
@@ -29,11 +27,19 @@ object Fcl {
 
     var currentUser: User? = null
 
-    fun init(env: Network, supportedWallets: List<Provider>, appDetail: AppDetail? = null): Config =
+    fun init(
+        env: Network,
+        supportedWallets: List<Provider>,
+        appDetail: AppDetail? = null,
+        accessNodeEndpoint: String? = null,
+        authnUrl: String? = null
+    ): Config =
         config.apply {
             put(Env(env))
             put(WalletProviders(supportedWallets))
             put(App(appDetail))
+            put(AccessNodeEndpoint(accessNodeEndpoint))
+            put(AuthnUrl(authnUrl))
         }
 
     /**

--- a/fcl/src/main/java/com/portto/fcl/config/Config.kt
+++ b/fcl/src/main/java/com/portto/fcl/config/Config.kt
@@ -23,6 +23,12 @@ object Config {
     var addressReplacement: List<Replacement> = emptyList()
         private set
 
+    var accessNodeEndpoint: String = ""
+        private set
+
+    var authnUrl: String = ""
+        private set
+
     fun put(option: Option): Config = apply {
         when (option) {
             is Option.Env -> env = option.value
@@ -35,6 +41,8 @@ object Config {
             }
             is Option.SelectedWalletProvider -> selectedWalletProvider = option.value
             is Option.AddressReplacement -> addressReplacement = option.value
+            is Option.AccessNodeEndpoint -> accessNodeEndpoint = (option.value ?: "")
+            is Option.AuthnUrl -> authnUrl = (option.value ?: "")
         }
     }
 
@@ -52,5 +60,7 @@ object Config {
         class WalletProviders(val value: List<Provider>) : Option()
         class SelectedWalletProvider(val value: Provider) : Option()
         class AddressReplacement(val value: List<Replacement>) : Option()
+        class AccessNodeEndpoint(val value: String?) : Option()
+        class AuthnUrl(val value: String?) : Option()
     }
 }

--- a/fcl/src/main/java/com/portto/fcl/provider/blocto/web/BloctoWebMethod.kt
+++ b/fcl/src/main/java/com/portto/fcl/provider/blocto/web/BloctoWebMethod.kt
@@ -25,7 +25,7 @@ internal object BloctoWebMethod : BloctoMethod {
         accountProofData: AccountProofResolvedData?
     ): User? {
         val response = execHttpPost(
-            url = getAuthnUrl(Fcl.isMainnet),
+            url = getAuthnUrl(Fcl.config.env),
             data = accountProofData?.toJsonObject()
         )
 

--- a/fcl/src/main/java/com/portto/fcl/provider/blocto/web/BloctoWebUtils.kt
+++ b/fcl/src/main/java/com/portto/fcl/provider/blocto/web/BloctoWebUtils.kt
@@ -1,10 +1,21 @@
 package com.portto.fcl.provider.blocto.web
 
+import com.portto.fcl.Fcl
+import com.portto.fcl.config.Network
+
 internal object BloctoWebUtils {
     private const val AUTHN_STAGING_URL = "https://flow-wallet-testnet.blocto.app/api/flow/authn"
     private const val AUTHN_PRODUCTION_URL = "https://flow-wallet.blocto.app/api/flow/authn"
 
-    fun getAuthnUrl(isMainnet: Boolean): String {
-        return if (isMainnet) AUTHN_PRODUCTION_URL else AUTHN_STAGING_URL
+    fun getAuthnUrl(env: Network?): String {
+        if (env == null) {
+            throw Exception("Network must be specified")
+        }
+        return when (env) {
+            Network.MAINNET -> AUTHN_PRODUCTION_URL
+            Network.TESTNET -> AUTHN_STAGING_URL
+            Network.LOCAL -> Fcl.config.authnUrl
+            Network.CANARYNET -> throw Exception("Canarynet not available")
+        }
     }
 }

--- a/fcl/src/main/java/com/portto/fcl/utils/AppUtils.kt
+++ b/fcl/src/main/java/com/portto/fcl/utils/AppUtils.kt
@@ -26,7 +26,13 @@ object AppUtils {
 
     internal val flowApi
         get() = Flow.newAccessApi(
-            host = if (Fcl.isMainnet) FLOW_MAINNET_ENDPOINT else FLOW_TESTNET_ENDPOINT
+            when (Fcl.config.env) {
+                Network.MAINNET -> FLOW_MAINNET_ENDPOINT
+                Network.TESTNET -> FLOW_TESTNET_ENDPOINT
+                Network.LOCAL -> Fcl.config.accessNodeEndpoint
+                Network.CANARYNET -> throw Exception("Canarynet not available")
+                null -> throw Exception("Network must be specified")
+            }
         )
 
     suspend fun verifyAccountProof(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ gradle-plugin = "7.2.2"
 kotlin = "1.7.10"
 
 androidx-activity = "1.5.1"
-androidx-compose = "1.1.1"
+androidx-compose = "1.2.1"
 androidx-lifecycle = "2.4.1"
 androidx-test = "1.4.0"
 blocto="0.4.0"


### PR DESCRIPTION
This should enable manually setting the access node and authn endpoint. A better solution might be to make them computed properties on the config object.

This will probably not work if the Blocto app is installed, it seems like they have a separate codepath for running transactions when they detect their app.